### PR TITLE
add mts as default extension

### DIFF
--- a/libs/first-package/src/constants.ts
+++ b/libs/first-package/src/constants.ts
@@ -3,6 +3,7 @@ export const defaultExtensions = [
   ".cjs",
   ".mjs",
   ".ts",
+  ".mts",
   ".tsx",
   ".jsx",
   ".vue",


### PR DESCRIPTION
### Release notes

#### Features
Add .mts as default extension
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @hipster/first-package@0.0.4-canary.5.453c80b.0
  # or 
  yarn add @hipster/first-package@0.0.4-canary.5.453c80b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
