### PR TITLE
feat: Introduce component-analyzer

### DIFF
--- a/libs/sb-utils/package.json
+++ b/libs/sb-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hipster/sb-utils",
   "version": "0.0.7",
-  "description": "Different, sometimes useful Storybook utilities",
+  "description": "A set of different utilities for Storybook",
   "type": "module",
   "license": "MIT",
   "homepage": "https://github.com/yannbf/sb-utils/tree/main/libs/sb-utils",
@@ -25,6 +25,10 @@
     "./uninstall": {
       "types": "./dist/commands/uninstall.d.mts",
       "default": "./dist/commands/uninstall.mjs"
+    },
+    "./component-analyzer": {
+      "types": "./dist/commands/component-analyzer.d.mts",
+      "default": "./dist/commands/component-analyzer.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/libs/sb-utils/playground/package.json
+++ b/libs/sb-utils/playground/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@storybook/addon-docs": "^8.0.0",
+    "@chromatic-com/storybook": "^3.0.0"
   }
 }

--- a/libs/sb-utils/src/bin.ts
+++ b/libs/sb-utils/src/bin.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { uninstall } from './commands/uninstall'
+import { runAnalyzeComponent } from './commands/component-analyzer'
 import { version } from '../package.json'
 
 const program = new Command()
@@ -20,6 +21,13 @@ program
   )
   .action(async (options) => {
     await uninstall(options).catch(console.error)
+  })
+
+program
+  .command('component-analyzer <file>')
+  .description('Analyze component complexity')
+  .action(async (filePath) => {
+    await runAnalyzeComponent({ filePath }).catch(console.error)
   })
 
 program.parse()

--- a/libs/sb-utils/src/commands/component-analyzer.ts
+++ b/libs/sb-utils/src/commands/component-analyzer.ts
@@ -1,0 +1,107 @@
+import { getComponentComplexity } from '../utils/get-component-complexity.js'
+export {
+  getComponentComplexity,
+  type ComponentComplexity,
+} from '../utils/get-component-complexity.js'
+
+export async function runAnalyzeComponent({
+  filePath,
+}: {
+  filePath: string
+}): Promise<void> {
+  try {
+    console.log(`Analyzing component complexity for: ${filePath}\n`)
+
+    const complexity = await getComponentComplexity(filePath)
+    const { low, high } = complexity.features
+
+    console.log('📊 Component Complexity Analysis')
+    console.log('='.repeat(50))
+
+    console.log(`File: ${low.meta.fileName}`)
+    console.log(`Directory: ${low.meta.directory}`)
+
+    console.log(`\n🏷️  Classification: ${complexity.type}`)
+
+    console.log('\n📏 Basic Metrics:')
+    console.log(`  Lines of code: ${low.metrics.totalLines}`)
+    console.log(`  Non-empty lines: ${low.metrics.nonEmptyLines}`)
+    console.log(
+      `  Non-empty runtime lines (excluding types): ${low.metrics.nonEmptyRuntimeLines}`
+    )
+
+    if (low.hooks.count > 0) {
+      console.log('\n🪝 Hooks:')
+      console.log(`  Count: ${low.hooks.count}`)
+      console.log(`  Custom hooks: ${high.hasCustomHooks ? 'Yes' : 'No'}`)
+      if (low.hooks.names.length > 0) {
+        console.log(`  Hook names: ${low.hooks.names.join(', ')}`)
+      }
+    }
+
+    if (low.imports.total > 0) {
+      console.log('\n📦 Dependencies:')
+      console.log(`  Total: ${low.imports.total}`)
+      console.log(`  External: ${low.imports.external.length}`)
+      console.log(`  Internal: ${low.imports.internal.length}`)
+      if (low.imports.react.length > 0) {
+        console.log(`  React imports: ${low.imports.react.join(', ')}`)
+      }
+      if (low.imports.external.length > 0) {
+        console.log(`  Third-party: ${low.imports.external.join(', ')}`)
+      }
+    }
+
+    const activePatterns: string[] = []
+    if (high.hasAuthIntegration) activePatterns.push('auth')
+    if (high.hasDataFetching) activePatterns.push('data-fetching')
+    if (high.hasRouting) activePatterns.push('router')
+    if (low.patternCounts.ASYNC > 0) activePatterns.push('async-operations')
+    if (low.patternCounts.ERROR_HANDLING > 0)
+      activePatterns.push('error-handling')
+    if (low.patternCounts.STATE_MANAGEMENT > 0)
+      activePatterns.push('state-management')
+    if (low.patternCounts.CONTEXT > 0) activePatterns.push('context-usage')
+    if (low.patternCounts.CSS_IN_JS > 0) activePatterns.push('css-in-js')
+
+    if (activePatterns.length > 0) {
+      console.log('\n🔍 Patterns Detected:')
+      console.log(`  ${activePatterns.join(', ')}`)
+    }
+
+    console.log('\n📈 Complexity Score:')
+    console.log(`  Overall score: ${complexity.score}/100`)
+
+    console.log('\nScore Breakdown:')
+    console.log(`  LOC score: ${complexity.breakdown.locScore}/20`)
+    console.log(`  Hooks score: ${complexity.breakdown.hooksScore}/15`)
+    console.log(
+      `  Dependencies score: ${complexity.breakdown.dependenciesScore}/15`
+    )
+    console.log(`  Patterns score: ${complexity.breakdown.patternsScore}/30`)
+    console.log(
+      `  Classification score: ${complexity.breakdown.classificationScore}/20`
+    )
+
+    // Complexity interpretation
+    let complexityLevel = 'Low'
+    if (complexity.score >= 70) {
+      complexityLevel = 'High'
+    } else if (complexity.score >= 40) {
+      complexityLevel = 'Medium'
+    }
+
+    console.log(`\nComplexity Level: ${complexityLevel} (${complexity.level})`)
+    if (complexity.factors.length > 0) {
+      console.log(`\nComplexity Factors: ${complexity.factors.join(', ')}`)
+    }
+  } catch (error) {
+    console.error('Error analyzing component:', error)
+    process.exit(1)
+  }
+}
+
+// Allow running directly as a script
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runAnalyzeComponent({ filePath: process.argv[2] })
+}

--- a/libs/sb-utils/src/commands/uninstall.ts
+++ b/libs/sb-utils/src/commands/uninstall.ts
@@ -145,14 +145,15 @@ export async function uninstall(options: UninstallOptions): Promise<void> {
     return
   }
 
-  const shouldRemoveStories = options.keepStories
-    ? false
-    : await confirm({
-        message: `Do you want to remove the ${storyFiles.length} story ${
-          storyFiles.length === 1 ? 'file' : 'files'
-        } and ${mdxFiles.length} MDX docs?`,
-        initialValue: true,
-      })
+  const shouldRemoveStories =
+    options.keepStories || (options.yes && !options.keepStories)
+      ? false
+      : await confirm({
+          message: `Do you want to remove the ${storyFiles.length} story ${
+            storyFiles.length === 1 ? 'file' : 'files'
+          } and ${mdxFiles.length} MDX docs?`,
+          initialValue: true,
+        })
 
   if (isCancel(shouldRemoveStories)) {
     note('Uninstallation cancelled.', 'Cancelled')

--- a/libs/sb-utils/src/utils/get-component-complexity.test.ts
+++ b/libs/sb-utils/src/utils/get-component-complexity.test.ts
@@ -81,6 +81,116 @@ describe('getComponentComplexity', () => {
     expect(result.breakdown.dependenciesScore).toBeGreaterThanOrEqual(0)
     expect(result.breakdown.patternsScore).toBeGreaterThanOrEqual(0)
     expect(result.breakdown.classificationScore).toBeGreaterThanOrEqual(0)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "breakdown": {
+          "classificationScore": 5,
+          "dependenciesScore": 2,
+          "hooksScore": 3,
+          "locScore": 0,
+          "patternsScore": 5,
+        },
+        "factors": [
+          "CSS-in-JS styling",
+          "Design system component",
+        ],
+        "features": {
+          "high": {
+            "dimensions": {
+              "coupling": 2,
+              "integration": 0,
+              "logic": 2,
+              "size": 1,
+            },
+            "hasAuthIntegration": false,
+            "hasComplexState": false,
+            "hasCustomHooks": false,
+            "hasDataFetching": false,
+            "hasRouting": false,
+            "isDesignSystemCandidate": true,
+            "isFeatureCandidate": false,
+            "isPageCandidate": false,
+          },
+          "low": {
+            "hooks": {
+              "count": 1,
+              "names": [
+                "useState",
+              ],
+            },
+            "imports": {
+              "external": [
+                "styled-components",
+              ],
+              "internal": [],
+              "react": [
+                "react",
+              ],
+              "total": 2,
+            },
+            "meta": {
+              "directory": "/components",
+              "fileName": "Button.tsx",
+              "filePath": "/components/Button.tsx",
+            },
+            "metrics": {
+              "nonEmptyLines": 20,
+              "nonEmptyRuntimeLines": 16,
+              "totalLines": 26,
+            },
+            "patternCounts": {
+              "ASYNC": 0,
+              "AUTH": 0,
+              "CONTEXT": 0,
+              "CSS_IN_JS": 2,
+              "DATA_FETCHING": 0,
+              "ERROR_HANDLING": 0,
+              "HOOKS": 1,
+              "ROUTER": 0,
+              "STATE_MANAGEMENT": 0,
+            },
+          },
+        },
+        "level": "simple",
+        "modelConfig": {
+          "CLASSIFICATION_BASE": {
+            "DEFAULT": 8,
+            "DESIGN_SYSTEM": 5,
+            "FEATURE": 12,
+            "PAGE": 15,
+            "UTILITY": 6,
+          },
+          "CUSTOM_HOOK_BONUS": 2,
+          "HOOKS_MAX_SCORE": 15,
+          "HOOK_MULTIPLIER": 1.5,
+          "IMPORT_DIVISOR": 1,
+          "IMPORT_MAX_SCORE": 15,
+          "LEVELS": {
+            "HIGH": 75,
+            "MEDIUM": 50,
+            "SIMPLE": 25,
+          },
+          "LOC_DIVISOR": 60,
+          "LOC_MAX_SCORE": 20,
+          "PATTERN_MAX_SCORE": 30,
+          "PATTERN_WEIGHTS": {
+            "ASYNC": 3,
+            "AUTH": 5,
+            "CONTEXT": 3,
+            "CSS_IN_JS": 4,
+            "DATA_FETCHING": 5,
+            "ERROR_HANDLING": 2,
+            "HOOKS": 1,
+            "ROUTER": 3,
+            "STATE_MANAGEMENT": 4,
+          },
+        },
+        "modelVersion": "1.0.0",
+        "score": 15,
+        "type": "design-system",
+      }
+    `)
   })
 
   test('does not treat type-heavy files as large components (runtime LOC excludes type/interface blocks)', async () => {

--- a/libs/sb-utils/src/utils/get-component-complexity.test.ts
+++ b/libs/sb-utils/src/utils/get-component-complexity.test.ts
@@ -1,0 +1,269 @@
+import { expect, test, describe, vi, beforeEach } from 'vitest'
+import { getComponentComplexity } from './get-component-complexity'
+// @ts-ignore
+import { readFile } from 'node:fs/promises'
+
+vi.mock('node:fs/promises')
+
+describe('getComponentComplexity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('analyzes a simple React component correctly', async () => {
+    const componentCode = `
+      import React, { useState } from 'react'
+      import { styled } from 'styled-components'
+
+      interface Props {
+        title: string
+        onClick?: () => void
+      }
+
+      export const Button: React.FC<Props> = ({ title, onClick }) => {
+        const [count, setCount] = useState(0)
+
+        return (
+          <Container>
+            <h1>{title}</h1>
+            <button onClick={onClick}>Click me</button>
+            <p>Count: {count}</p>
+          </Container>
+        )
+      }
+
+      const Container = styled.div\`
+        padding: 20px;
+        border: 1px solid #ccc;
+      \`
+      `
+
+    vi.mocked(readFile).mockResolvedValue(componentCode)
+
+    const result = await getComponentComplexity('/components/Button.tsx')
+    const { low, high } = result.features
+
+    // Basic file info
+    expect(low.meta.fileName).toBe('Button.tsx')
+    expect(low.metrics.totalLines).toBeGreaterThan(10)
+    expect(low.metrics.nonEmptyLines).toBeGreaterThan(5)
+    expect(low.metrics.nonEmptyRuntimeLines).toBeGreaterThan(0)
+    expect(low.metrics.nonEmptyRuntimeLines).toBeLessThanOrEqual(
+      low.metrics.nonEmptyLines
+    )
+
+    // Hooks analysis
+    expect(low.hooks.count).toBe(1)
+    expect(low.hooks.names).toContain('useState')
+    expect(high.hasCustomHooks).toBe(false)
+
+    // Dependencies
+    expect(low.imports.total).toBeGreaterThan(0)
+    expect(low.imports.react).toContain('react')
+    expect(low.imports.external).toContain('styled-components')
+
+    // Patterns
+    expect(low.patternCounts.CSS_IN_JS).toBeGreaterThan(0) // Should detect styled-components usage
+    expect(low.patternCounts.STATE_MANAGEMENT).toBe(0) // useState alone doesn't count as state management
+    expect(high.hasAuthIntegration).toBe(false)
+    expect(high.hasDataFetching).toBe(false)
+
+    // Classification
+    expect(result.type).toBe('design-system') // "Button.tsx" -> design system
+    expect(typeof result.score).toBe('number')
+    expect(result.score).toBeGreaterThanOrEqual(0)
+    expect(result.score).toBeLessThanOrEqual(100)
+
+    // Score breakdown
+    expect(result.breakdown).toBeDefined()
+    expect(result.breakdown.locScore).toBeGreaterThanOrEqual(0)
+    expect(result.breakdown.hooksScore).toBeGreaterThanOrEqual(0)
+    expect(result.breakdown.dependenciesScore).toBeGreaterThanOrEqual(0)
+    expect(result.breakdown.patternsScore).toBeGreaterThanOrEqual(0)
+    expect(result.breakdown.classificationScore).toBeGreaterThanOrEqual(0)
+  })
+
+  test('does not treat type-heavy files as large components (runtime LOC excludes type/interface blocks)', async () => {
+    const tinyRuntime = `
+      import React from 'react'
+
+      type SomeProps = {
+        a: string
+        b: number
+        c: boolean
+        d: string[]
+        e: {
+          f: string
+          g: number
+          h: boolean
+          i: string[]
+          j: {
+            k: string
+            l: number
+            m: boolean
+          }
+        }
+      }
+
+      interface SomeProps extends OtherProps {
+        a: string
+        b: number
+        c: boolean
+        d: string[]
+        e: {
+          f: string
+          g: number
+          h: boolean
+          i: string[]
+          j: {
+            k: string
+            l: number
+            m: boolean
+          }
+        }
+      }
+
+      export const Tiny: React.FC = () => {
+        return <div>ok</div>
+      }
+    `
+
+    vi.mocked(readFile).mockResolvedValue(tinyRuntime)
+
+    const result = await getComponentComplexity('/components/Tiny.tsx')
+    const { low } = result.features
+
+    expect(low.metrics.totalLines).toBe(43)
+    expect(low.metrics.nonEmptyLines).toBe(38)
+    expect(low.metrics.nonEmptyRuntimeLines).toBe(4)
+
+    expect(result.factors).not.toContain('Large component size')
+  })
+
+  test('analyzes a complex component with multiple patterns', async () => {
+    const complexComponentCode = `
+      import React, { useState, useEffect, useContext } from 'react'
+      import { useRouter } from 'next/router'
+      import { useQuery } from '@tanstack/react-query'
+      import { AuthContext } from '../contexts/AuthContext'
+      import { api } from '../services/api'
+      import styled from 'styled-components'
+
+      interface ComplexComponentProps {
+        userId: string
+        onSuccess: (data: any) => void
+      }
+
+      export const ComplexComponent: React.FC<ComplexComponentProps> = ({
+        userId,
+        onSuccess
+      }) => {
+        const [data, setData] = useState(null)
+        const [loading, setLoading] = useState(true)
+        const [error, setError] = useState<string | null>(null)
+
+        const router = useRouter()
+        const { user, isAuthenticated } = useContext(AuthContext)
+
+        const { data: fetchedData, isLoading, error: queryError } = useQuery({
+          queryKey: ['user', userId],
+          queryFn: () => api.getUser(userId),
+          enabled: !!userId && isAuthenticated
+        })
+
+        useEffect(() => {
+          if (fetchedData) {
+            setData(fetchedData)
+            setLoading(false)
+            onSuccess(fetchedData)
+          }
+        }, [fetchedData, onSuccess])
+
+        useEffect(() => {
+          if (queryError) {
+            setError('Failed to fetch user data')
+            setLoading(false)
+          }
+        }, [queryError])
+
+        const handleRetry = async () => {
+          try {
+            setError(null)
+            setLoading(true)
+            const result = await api.getUser(userId)
+            setData(result)
+            setLoading(false)
+          } catch (err) {
+            setError('Retry failed')
+            setLoading(false)
+          }
+        }
+
+        if (!isAuthenticated) {
+          router.push('/login')
+          return null
+        }
+
+        return (
+          <Container>
+            {loading && <div>Loading...</div>}
+            {error && (
+              <ErrorContainer>
+                <p>{error}</p>
+                <button onClick={handleRetry}>Retry</button>
+              </ErrorContainer>
+            )}
+            {data && <UserData data={data} />}
+          </Container>
+        )
+      }
+
+      const Container = styled.div\`
+        padding: 20px;
+      \`
+
+      const ErrorContainer = styled.div\`
+        color: red;
+        border: 1px solid red;
+        padding: 10px;
+        margin: 10px 0;
+      \`
+
+      const UserData = styled.div\`
+        background: #f5f5f5;
+        padding: 15px;
+        border-radius: 4px;
+      \`
+      `
+
+    vi.mocked(readFile).mockResolvedValue(complexComponentCode)
+
+    const result = await getComponentComplexity('/path/to/ComplexComponent.tsx')
+    const { low, high } = result.features
+
+    // Should detect multiple patterns (High level booleans or low level counts)
+    expect(high.hasAuthIntegration).toBe(true)
+    expect(high.hasDataFetching).toBe(true)
+    expect(high.hasRouting).toBe(true)
+
+    expect(low.patternCounts.ASYNC).toBeGreaterThan(0)
+    expect(low.patternCounts.ERROR_HANDLING).toBeGreaterThan(0)
+    expect(low.patternCounts.STATE_MANAGEMENT).toBeGreaterThan(0) // useContext is counted here
+    expect(low.patternCounts.CONTEXT).toBeGreaterThan(0)
+    expect(low.patternCounts.CSS_IN_JS).toBeGreaterThan(0)
+
+    // Should have higher complexity score due to multiple patterns
+    expect(result.score).toBeGreaterThan(20)
+
+    // Should detect multiple hooks
+    expect(low.hooks.count).toBeGreaterThan(2)
+    expect(low.hooks.names).toContain('useState')
+    expect(low.hooks.names).toContain('useEffect')
+    expect(low.hooks.names).toContain('useContext')
+
+    // Should detect third-party dependencies
+    expect(low.imports.external).toContain('@tanstack/react-query')
+    expect(low.imports.external).toContain('next/router')
+    expect(low.imports.external).toContain('styled-components')
+  })
+})

--- a/libs/sb-utils/src/utils/get-component-complexity.ts
+++ b/libs/sb-utils/src/utils/get-component-complexity.ts
@@ -336,7 +336,6 @@ export interface ComponentComplexity extends ComplexityClassification {
     low: LowLevelFeatures
     high: HighLevelFeatures
   }
-  timestamp: string
 }
 
 // Snapshot format (persisted)
@@ -715,7 +714,6 @@ export async function getComponentComplexity(
         low: lowLevel,
         high: highLevel,
       },
-      timestamp: new Date().toISOString(),
     }
 
     return result

--- a/libs/sb-utils/src/utils/get-component-complexity.ts
+++ b/libs/sb-utils/src/utils/get-component-complexity.ts
@@ -1,0 +1,817 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+// -----------------------------
+// Versioning & Config
+// -----------------------------
+export const MODEL_VERSION = '1.0.0'
+
+export type ModelConfig = {
+  // scaling constants
+  LOC_DIVISOR: number
+  LOC_MAX_SCORE: number
+
+  // coupling / imports
+  IMPORT_DIVISOR: number
+  IMPORT_MAX_SCORE: number
+
+  // hooks / logic
+  HOOK_MULTIPLIER: number
+  HOOKS_MAX_SCORE: number
+  CUSTOM_HOOK_BONUS: number
+
+  // integration pattern weights (raw)
+  PATTERN_WEIGHTS: Record<string, number>
+  PATTERN_MAX_SCORE: number
+
+  // classification base scores
+  CLASSIFICATION_BASE: {
+    DEFAULT: number
+    DESIGN_SYSTEM: number
+    PAGE: number
+    FEATURE: number
+    UTILITY: number
+  }
+
+  // final thresholds for levels
+  LEVELS: {
+    SIMPLE: number // <=
+    MEDIUM: number // <=
+    HIGH: number // <=
+    // very-high is > HIGH
+  }
+}
+
+export const DEFAULT_MODEL_CONFIG: ModelConfig = {
+  // Non-empty, non-typescript types amount of lines to consider
+  // It is multiplied by 5 so currently large component is considered to have more than 300 lines of code (without counting empty spaces and types).
+  LOC_DIVISOR: 60,
+  LOC_MAX_SCORE: 20, // maps to breakdown locScore (0-20)
+
+  IMPORT_DIVISOR: 1,
+  IMPORT_MAX_SCORE: 15,
+
+  HOOK_MULTIPLIER: 1.5,
+  HOOKS_MAX_SCORE: 15,
+  CUSTOM_HOOK_BONUS: 2,
+
+  PATTERN_WEIGHTS: {
+    AUTH: 5,
+    DATA_FETCHING: 5,
+    ROUTER: 3,
+    ASYNC: 3,
+    ERROR_HANDLING: 2,
+    STATE_MANAGEMENT: 4,
+    CONTEXT: 3,
+    CSS_IN_JS: 4,
+    HOOKS: 1, // fallback
+  },
+  PATTERN_MAX_SCORE: 30,
+
+  CLASSIFICATION_BASE: {
+    DEFAULT: 8,
+    DESIGN_SYSTEM: 5,
+    PAGE: 15,
+    FEATURE: 12,
+    UTILITY: 6,
+  },
+
+  LEVELS: {
+    SIMPLE: 25,
+    MEDIUM: 50,
+    HIGH: 75,
+  },
+}
+
+// -----------------------------
+// PATTERNS & Constants (unchanged, but exposed)
+// -----------------------------
+const DESIGN_SYSTEM_NAMES = [
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'checkbox',
+  'radio',
+  'switch',
+  'toggle',
+  'icon',
+  'avatar',
+  'badge',
+  'tag',
+  'label',
+  'tooltip',
+  'popover',
+  'modal',
+  'dialog',
+  'dropdown',
+  'menu',
+  'navbar',
+  'nav',
+  'tab',
+  'accordion',
+  'card',
+  'alert',
+  'notification',
+  'toast',
+  'spinner',
+  'loader',
+  'progress',
+  'slider',
+  'table',
+  'form',
+  'field',
+  'text',
+  'heading',
+  'title',
+  'link',
+  'anchor',
+]
+
+const PAGE_NAMES = [
+  'page',
+  'screen',
+  'view',
+  'dashboard',
+  'profile',
+  'settings',
+  'login',
+  'register',
+  'signup',
+  'home',
+  'landing',
+  'admin',
+]
+
+const FEATURE_INDICATORS = ['feature', 'features', 'module', 'domain']
+
+const PATTERNS = {
+  HOOKS: [
+    /\buse[A-Z]\w*(?:\s*<[^>]*>)?\s*\(/g,
+    /\bReact\.use[A-Z]\w*(?:\s*<[^>]*>)?\s*\(/g,
+    /\buse\w+\s*=\s*use[A-Z]\w*(?:\s*<[^>]*>)?\s*\(/g,
+  ],
+  AUTH: [
+    /\bauth\b/i,
+    /\blogin\b/i,
+    /\blogout\b/i,
+    /\bsignin\b/i,
+    /\bsignout\b/i,
+    /\bauthentication\b/i,
+    /\bauthorization\b/i,
+    /\btoken\b/i,
+    /\bsession\b/i,
+    /\buser\b\s*\.\s*\w+/i,
+    /\bpermission\b/i,
+    /\brole\b/i,
+    /\buseAuth\b/i,
+    /\bAuthProvider\b/i,
+  ],
+  DATA_FETCHING: [
+    /\bfetch\s*\(/,
+    /\baxios\s*\./,
+    /\bapi\s*\//,
+    /\bhttp\s*\//,
+    /\bgraphql/i,
+    /\bquery\s*\(/,
+    /\bmutation\s*\(/,
+    /\buseQuery\s*\(/,
+    /\buseMutation\s*\(/,
+    /\bswr\s*\(/,
+    /\breact-query/i,
+    /\bapollo/i,
+  ],
+  ROUTER: [
+    /\buseRouter\b/,
+    /\buseNavigate\b/,
+    /\buseParams\b/,
+    /\buseLocation\b/,
+    /\bLink\s+from\s+['"]react-router/i,
+    /\bNavLink\s+from\s+['"]react-router/i,
+    /\bBrowserRouter\b/,
+    /\bRoutes\b/,
+    /\bRoute\b/,
+    /\bnext\/router/i,
+    /\bnext\/navigation/i,
+  ],
+  ASYNC: [
+    /\basync\s+/,
+    /\bawait\s+/,
+    /\bPromise\s*\./,
+    /\bthen\s*\(/,
+    /\bcatch\s*\(/,
+    /\buseAsync\b/i,
+  ],
+  ERROR_HANDLING: [
+    /\btry\s*\{/,
+    /\bcatch\s*\(/,
+    /\bError\s*\(/,
+    /\bthrow\s+/,
+    /\buseError\b/i,
+    /\berror\s*boundary/i,
+  ],
+  STATE_MANAGEMENT: [
+    /\buseReducer\b/,
+    /\buseContext\b/,
+    /\buseStore\b/i,
+    /\buseSelector\b/i,
+    /\buseDispatch\b/i,
+    /\bredux/i,
+    /\bzustand/i,
+    /\bjotai/i,
+    /\brecoil/i,
+  ],
+  CONTEXT: [
+    /\bcreateContext\b/,
+    /\buseContext\b/,
+    /\bContext\.Provider\b/,
+    /\bContext\.Consumer\b/,
+  ],
+  CSS_IN_JS: [
+    /\bimport.*styled.*from.*styled-components\b/,
+    /\bstyled\.\w+\s*</,
+    /\bstyled\.\w+\s*`/,
+    /\bcss\s*`/,
+    /\bkeyframes\s*\(/,
+    /@emotion/,
+    /styled-jsx/,
+    /linaria/,
+    /react-jss/,
+    /vanilla-extract/,
+  ],
+} as const
+
+export type FeatureCategory = keyof typeof PATTERNS
+export type ComplexityPattern =
+  | 'auth'
+  | 'data-fetching'
+  | 'router'
+  | 'async-operations'
+  | 'error-handling'
+  | 'state-management'
+  | 'context-usage'
+  | 'css-in-js'
+
+export type ComponentType =
+  | 'design-system'
+  | 'page'
+  | 'feature'
+  | 'utility'
+  | 'unknown'
+
+export type ComplexityLevel = 'simple' | 'medium' | 'high' | 'very-high'
+
+// -----------------------------
+// 2. Data Structures
+// -----------------------------
+export interface LowLevelFeatures {
+  meta: {
+    filePath: string
+    fileName: string
+    directory: string
+  }
+  metrics: {
+    totalLines: number
+    nonEmptyLines: number
+    /**
+     * Non-empty lines excluding top-level TypeScript type-only declarations
+     * like `type X = ...` and `interface X { ... }` (and `export type { ... }`).
+     *
+     * This is intended to better approximate "runtime" component size when a file
+     * contains many types/interfaces.
+     */
+    nonEmptyRuntimeLines: number
+  }
+  imports: {
+    total: number
+    react: string[]
+    external: string[]
+    internal: string[]
+  }
+  hooks: {
+    count: number
+    names: string[]
+  }
+  // Counts of pattern matches per category
+  patternCounts: Record<FeatureCategory, number>
+}
+
+export interface HighLevelFeatures {
+  isDesignSystemCandidate: boolean
+  isPageCandidate: boolean
+  isFeatureCandidate: boolean
+
+  hasCustomHooks: boolean
+  hasComplexState: boolean
+  hasAuthIntegration: boolean
+  hasDataFetching: boolean
+  hasRouting: boolean
+
+  dimensions: {
+    size: number
+    coupling: number
+    logic: number
+    integration: number
+  }
+}
+
+export interface ComplexityClassification {
+  modelVersion: string
+  modelConfig: ModelConfig
+  score: number // 0-100
+  level: ComplexityLevel
+  type: ComponentType
+  factors: string[]
+  breakdown: {
+    locScore: number
+    hooksScore: number
+    dependenciesScore: number
+    patternsScore: number
+    classificationScore: number
+  }
+}
+
+export interface ComponentComplexity extends ComplexityClassification {
+  features: {
+    low: LowLevelFeatures
+    high: HighLevelFeatures
+  }
+  timestamp: string
+}
+
+// Snapshot format (persisted)
+export interface ComponentSnapshot {
+  modelVersion: string
+  modelConfig: ModelConfig
+  result: ComponentComplexity
+}
+
+function braceDelta(line: string): number {
+  // Lightweight heuristic: count braces without trying to parse strings/comments.
+  // This is "good enough" for typical type/interface blocks.
+  let delta = 0
+  for (const ch of line) {
+    if (ch === '{') delta += 1
+    else if (ch === '}') delta -= 1
+  }
+  return delta
+}
+
+function countNonEmptyRuntimeLines(lines: string[]): number {
+  // Excludes top-level TypeScript-only declarations that often bloat LOC:
+  // - type Foo = ...
+  // - interface Foo { ... }
+  // - export type { Foo } from '...'
+  //
+  // Heuristic approach (no TS compiler API at runtime).
+  const TYPE_OR_INTERFACE_DECL_RE =
+    /^\s*(export\s+)?(declare\s+)?(type|interface)\s+[A-Za-z_$][\w$]*/
+  const TYPE_ONLY_EXPORT_RE = /^\s*export\s+type\s*\{/
+
+  let nonEmptyRuntimeLines = 0
+  let inTypeBlock = false
+  let typeBraceDepth = 0
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+
+    // Exclude type-only export lines (no runtime impact).
+    if (!inTypeBlock && TYPE_ONLY_EXPORT_RE.test(trimmed)) {
+      continue
+    }
+
+    if (!inTypeBlock && TYPE_OR_INTERFACE_DECL_RE.test(trimmed)) {
+      inTypeBlock = true
+      typeBraceDepth += braceDelta(trimmed)
+
+      // End immediately for one-liners like:
+      // - interface X {}
+      // - type X = { ... }
+      // - type X = Foo | Bar;
+      const endsWithSemicolon = /;\s*$/.test(trimmed)
+      const endsWithClosingBrace = /}\s*;?\s*$/.test(trimmed)
+      const oneLineBraceBlock = trimmed.includes('{') && trimmed.includes('}')
+      if (
+        typeBraceDepth <= 0 &&
+        (endsWithSemicolon || endsWithClosingBrace || oneLineBraceBlock)
+      ) {
+        inTypeBlock = false
+        typeBraceDepth = 0
+      }
+      continue
+    }
+
+    if (inTypeBlock) {
+      typeBraceDepth += braceDelta(trimmed)
+      const endsWithSemicolon = /;\s*$/.test(trimmed)
+      const endsWithClosingBrace = /}\s*;?\s*$/.test(trimmed)
+      if (typeBraceDepth <= 0 && (endsWithSemicolon || endsWithClosingBrace)) {
+        inTypeBlock = false
+        typeBraceDepth = 0
+      }
+      continue
+    }
+
+    nonEmptyRuntimeLines += 1
+  }
+
+  return nonEmptyRuntimeLines
+}
+
+// -----------------------------
+// 3. Extraction (ETL)
+// -----------------------------
+export async function extractLowLevelFeatures(
+  filePath: string,
+  content?: string
+): Promise<LowLevelFeatures> {
+  const fileContent = content ?? (await readFile(filePath, 'utf-8'))
+  const lines = fileContent.split('\n')
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0).length
+  const nonEmptyRuntimeLines = countNonEmptyRuntimeLines(lines)
+
+  // Import Analysis
+  const importLines = lines.filter((line) => line.trim().startsWith('import'))
+  const reactImports: string[] = []
+  const externalImports: string[] = []
+  const internalImports: string[] = []
+
+  for (const line of importLines) {
+    const fromMatch = line.match(/from\s+['"]([^'"]+)['"]/)
+    const pathMatch = line.match(/import\s+['"]([^'"]+)['"]/)
+    const importPath = fromMatch?.[1] ?? pathMatch?.[1]
+
+    if (importPath) {
+      if (
+        importPath === 'react' ||
+        importPath.startsWith('react/') ||
+        importPath.startsWith('@types/react')
+      ) {
+        reactImports.push(importPath)
+      } else if (importPath.startsWith('.') || importPath.startsWith('/')) {
+        internalImports.push(importPath)
+      } else {
+        externalImports.push(importPath)
+      }
+    }
+  }
+
+  // Hook Analysis - collect raw matches and canonicalize names
+  const hookNames = new Set<string>()
+  for (const pattern of PATTERNS.HOOKS) {
+    const matches = fileContent.match(pattern)
+    if (matches) {
+      for (const match of matches) {
+        // Extract candidate like "useSomething("
+        const nameMatch = match.match(/\b(use[A-Z]\w*)/)
+        if (nameMatch) {
+          hookNames.add(nameMatch[1])
+        }
+      }
+    }
+  }
+
+  // Pattern Counts
+  const patternCounts = {} as Record<FeatureCategory, number>
+  for (const key of Object.keys(PATTERNS) as FeatureCategory[]) {
+    let count = 0
+    for (const pattern of PATTERNS[key]) {
+      const matches = fileContent.match(pattern)
+      if (matches) count += matches.length
+    }
+    patternCounts[key] = count
+  }
+
+  return {
+    meta: {
+      filePath,
+      fileName: basename(filePath),
+      directory: dirname(filePath),
+    },
+    metrics: {
+      totalLines: lines.length,
+      nonEmptyLines,
+      nonEmptyRuntimeLines,
+    },
+    imports: {
+      total:
+        reactImports.length + externalImports.length + internalImports.length,
+      react: reactImports,
+      external: externalImports,
+      internal: internalImports,
+    },
+    hooks: {
+      count: hookNames.size,
+      names: Array.from(hookNames),
+    },
+    patternCounts,
+  }
+}
+
+// -----------------------------
+// 4. Feature Engineering
+// -----------------------------
+export function synthesizeHighLevelFeatures(
+  low: LowLevelFeatures
+): HighLevelFeatures {
+  const { fileName, directory } = low.meta
+  const fileNameLower = fileName.toLowerCase()
+  const pathLower = (directory + '/' + fileName).toLowerCase()
+
+  // Classification Candidates
+  const isDesignSystemCandidate = DESIGN_SYSTEM_NAMES.some(
+    (name) =>
+      fileNameLower.includes(name) &&
+      !fileNameLower.includes('page') &&
+      !fileNameLower.includes('screen')
+  )
+
+  const isPageCandidate = PAGE_NAMES.some((name) =>
+    fileNameLower.includes(name)
+  )
+
+  const isFeatureCandidate = FEATURE_INDICATORS.some((indicator) =>
+    pathLower.includes(indicator)
+  )
+
+  // Complexity Heuristics
+  const hasCustomHooks = low.hooks.names.some(
+    (name) =>
+      !name.startsWith('useState') &&
+      !name.startsWith('useEffect') &&
+      !name.startsWith('useCallback') &&
+      !name.startsWith('useMemo') &&
+      !name.startsWith('useRef')
+  )
+
+  // Dimension Scoring (normalized-ish)
+  const size = Math.round(Math.min(10, low.metrics.nonEmptyRuntimeLines / 20)) // 0-10
+  const coupling = Math.round(Math.min(10, low.imports.total / 1)) // 0-10
+  const logic = Math.round(
+    Math.min(10, low.hooks.count * 1.5 + (hasCustomHooks ? 1 : 0))
+  ) // 0-10
+
+  // Integration: presence of key patterns
+  let integrationRaw = 0
+  if (low.patternCounts.AUTH > 0) integrationRaw += 3
+  if (low.patternCounts.DATA_FETCHING > 0) integrationRaw += 3
+  if (low.patternCounts.ROUTER > 0) integrationRaw += 2
+  if (low.patternCounts.STATE_MANAGEMENT > 0) integrationRaw += 2
+  const integration = Math.min(10, integrationRaw)
+
+  return {
+    isDesignSystemCandidate,
+    isPageCandidate,
+    isFeatureCandidate,
+    hasCustomHooks,
+    hasComplexState: low.patternCounts.STATE_MANAGEMENT > 0,
+    hasAuthIntegration: low.patternCounts.AUTH > 0,
+    hasDataFetching: low.patternCounts.DATA_FETCHING > 0,
+    hasRouting: low.patternCounts.ROUTER > 0,
+    dimensions: {
+      size,
+      coupling,
+      logic,
+      integration,
+    },
+  }
+}
+
+// -----------------------------
+// 5. Classification (The Model)
+// -----------------------------
+export function classifyComplexityWithConfig(
+  low: LowLevelFeatures,
+  high: HighLevelFeatures,
+  config: ModelConfig
+): ComplexityClassification {
+  // 1. Determine Component Type
+  let type: ComponentType = 'unknown'
+  if (high.isDesignSystemCandidate) type = 'design-system'
+  else if (high.isPageCandidate) type = 'page'
+  else if (high.isFeatureCandidate) type = 'feature'
+  else if (low.meta.fileName.toLowerCase().includes('util')) type = 'utility'
+
+  // 2. Calculate Sub-Scores (mapping to breakdown scales)
+  // locScore: scale nonEmptyRuntimeLines -> [0 .. config.LOC_MAX_SCORE]
+  const locRaw = Math.floor(
+    low.metrics.nonEmptyRuntimeLines / config.LOC_DIVISOR
+  )
+  const locScore = Math.min(config.LOC_MAX_SCORE, locRaw)
+
+  // hooksScore: from high.dimensions.logic but scaled to HOOKS_MAX_SCORE
+  const hooksScore = Math.min(
+    config.HOOKS_MAX_SCORE,
+    Math.floor(high.dimensions.logic * config.HOOK_MULTIPLIER) +
+      (high.hasCustomHooks ? config.CUSTOM_HOOK_BONUS : 0)
+  )
+
+  // dependenciesScore (imports)
+  const dependenciesScore = Math.min(
+    config.IMPORT_MAX_SCORE,
+    Math.floor(low.imports.total / config.IMPORT_DIVISOR)
+  )
+
+  // Pattern Score: weighted by PATTERN_WEIGHTS
+  let patternsScore = 0
+  for (const [patternKey, weight] of Object.entries(config.PATTERN_WEIGHTS)) {
+    // map from config key to our PATTERNS keys - use case-insensitive matching
+    const upperKey = patternKey.toUpperCase()
+    // If pattern exists in PATTERNS, use counts; otherwise treat as zero
+    if ((PATTERNS as any)[upperKey]) {
+      const count = (low.patternCounts as any)[upperKey] ?? 0
+      if (count > 0) patternsScore += weight
+    } else {
+      // fallback: attempt direct mapping (e.g. "ERROR_HANDLING")
+      const count = (low.patternCounts as any)[upperKey] ?? 0
+      if (count > 0) patternsScore += weight
+    }
+  }
+  patternsScore = Math.min(config.PATTERN_MAX_SCORE, patternsScore)
+
+  // Classification Score (contextual base)
+  let classificationScore = config.CLASSIFICATION_BASE.DEFAULT
+  if (type === 'design-system')
+    classificationScore = config.CLASSIFICATION_BASE.DESIGN_SYSTEM
+  else if (type === 'page')
+    classificationScore = config.CLASSIFICATION_BASE.PAGE
+  else if (type === 'feature')
+    classificationScore = config.CLASSIFICATION_BASE.FEATURE
+  else if (type === 'utility')
+    classificationScore = config.CLASSIFICATION_BASE.UTILITY
+
+  // Total Score
+  const rawScore =
+    locScore +
+    hooksScore +
+    dependenciesScore +
+    patternsScore +
+    classificationScore
+  const complexityScore = Math.min(100, Math.round(rawScore))
+
+  // Complexity Level
+  let level: ComplexityLevel
+  if (complexityScore <= config.LEVELS.SIMPLE) level = 'simple'
+  else if (complexityScore <= config.LEVELS.MEDIUM) level = 'medium'
+  else if (complexityScore <= config.LEVELS.HIGH) level = 'high'
+  else level = 'very-high'
+
+  // Factors (top reasons) - deterministic selection order
+  const factors: string[] = []
+  if (low.metrics.nonEmptyRuntimeLines > config.LOC_DIVISOR * 5)
+    factors.push('Large component size')
+  if (low.hooks.count > 3) factors.push('Multiple hooks usage')
+  if (low.imports.total > 5) factors.push('High dependency count')
+  if (high.hasAuthIntegration) factors.push('Authentication logic')
+  if (high.hasDataFetching) factors.push('Data fetching operations')
+  if (low.patternCounts.STATE_MANAGEMENT > 0) factors.push('State management')
+  if (low.patternCounts.CSS_IN_JS > 0) factors.push('CSS-in-JS styling')
+  if (high.hasRouting) factors.push('Router integration')
+  if (low.patternCounts.ASYNC > 0) factors.push('Async operations')
+  if (low.patternCounts.CONTEXT > 0) factors.push('Context usage')
+  if (low.patternCounts.ERROR_HANDLING > 0) factors.push('Error handling')
+
+  if (type === 'page') factors.push('Page component')
+  else if (type === 'feature') factors.push('Feature component')
+  else if (type === 'design-system') factors.push('Design system component')
+
+  return {
+    modelVersion: MODEL_VERSION,
+    modelConfig: config,
+    score: complexityScore,
+    level,
+    type,
+    factors: factors.slice(0, 6), // keep to a reasonable number
+    breakdown: {
+      locScore,
+      hooksScore,
+      dependenciesScore,
+      patternsScore,
+      classificationScore,
+    },
+  }
+}
+
+// -----------------------------
+// 6. Public API (Pipeline Execution)
+// -----------------------------
+export async function getComponentComplexity(
+  filePath: string,
+  config: ModelConfig = DEFAULT_MODEL_CONFIG
+): Promise<ComponentComplexity> {
+  try {
+    const lowLevel = await extractLowLevelFeatures(filePath)
+    const highLevel = synthesizeHighLevelFeatures(lowLevel)
+    const classification = classifyComplexityWithConfig(
+      lowLevel,
+      highLevel,
+      config
+    )
+
+    const result: ComponentComplexity = {
+      ...classification,
+      features: {
+        low: lowLevel,
+        high: highLevel,
+      },
+      timestamp: new Date().toISOString(),
+    }
+
+    return result
+  } catch (error) {
+    throw new Error(
+      `Failed to analyze component complexity for ${filePath}: ${String(error)}`
+    )
+  }
+}
+
+// -----------------------------
+// 7. Persistence Utilities (Snapshots)
+// -----------------------------
+export async function saveSnapshot(
+  componentComplexity: ComponentComplexity,
+  outPath: string
+): Promise<void> {
+  const dir = dirname(outPath)
+  try {
+    // Ensure directory exists (simple attempt)
+    await mkdir(dir, { recursive: true })
+  } catch {
+    // ignore
+  }
+  const snapshot: ComponentSnapshot = {
+    modelVersion: componentComplexity.modelVersion,
+    modelConfig: componentComplexity.modelConfig,
+    result: componentComplexity,
+  }
+  await writeFile(outPath, JSON.stringify(snapshot, null, 2), 'utf-8')
+}
+
+export async function loadSnapshot(path: string): Promise<ComponentSnapshot> {
+  const content = await readFile(path, 'utf-8')
+  const parsed = JSON.parse(content) as ComponentSnapshot
+  return parsed
+}
+
+// -----------------------------
+// 8. Reclassification Helpers
+//    (Re-run classification deterministically on raw low-level features)
+// -----------------------------
+export function reclassifyWithConfig(
+  low: LowLevelFeatures,
+  config: ModelConfig = DEFAULT_MODEL_CONFIG
+): ComplexityClassification {
+  const high = synthesizeHighLevelFeatures(low)
+  return classifyComplexityWithConfig(low, high, config)
+}
+
+// -----------------------------
+// 9. CLI convenience (minimal)
+// -----------------------------
+export async function runAndMaybeSave(
+  filePath: string,
+  options?: { saveSnapshot?: boolean; outDir?: string; config?: ModelConfig }
+): Promise<ComponentComplexity> {
+  const config = options?.config ?? DEFAULT_MODEL_CONFIG
+  const result = await getComponentComplexity(filePath, config)
+  if (options?.saveSnapshot) {
+    const name = `${basename(filePath).replace(/\.[^.]+$/, '')}.complexity.json`
+    const outDir = options.outDir ?? './component-complexity-snapshots'
+    const outPath = join(outDir, name)
+    await saveSnapshot(result, outPath)
+  }
+  return result
+}
+
+// -----------------------------
+// 10. Small utilities for debugging
+// -----------------------------
+export function prettyPrint(result: ComponentComplexity): string {
+  return [
+    `Component: ${result.features.low.meta.filePath}`,
+    `Model version: ${result.modelVersion}`,
+    `Score: ${result.score} (${result.level})`,
+    `Type: ${result.type}`,
+    `Factors: ${result.factors.join(', ')}`,
+    `Breakdown: ${JSON.stringify(result.breakdown)}`,
+    `Dimensions: ${JSON.stringify(result.features.high.dimensions)}`,
+  ].join('\n')
+}
+
+// -----------------------------
+// 11. Exports (default and named)
+// -----------------------------
+export default {
+  MODEL_VERSION,
+  DEFAULT_MODEL_CONFIG,
+  extractLowLevelFeatures,
+  synthesizeHighLevelFeatures,
+  classifyComplexityWithConfig,
+  getComponentComplexity,
+  saveSnapshot,
+  loadSnapshot,
+  reclassifyWithConfig,
+  runAndMaybeSave,
+  prettyPrint,
+}

--- a/libs/sb-utils/tsdown.config.ts
+++ b/libs/sb-utils/tsdown.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/bin.ts', 'src/commands/uninstall.ts'],
+  entry: [
+    'src/bin.ts',
+    'src/commands/uninstall.ts',
+    'src/commands/component-analyzer.ts',
+  ],
   banner: {
     js: '#!/usr/bin/env node',
   },


### PR DESCRIPTION
Feature: Add Component Analyzer (CLI + Node API)

This PR introduces a Component Analyzer, a command and node API which inspects a component and provides complexity features, scores and factors. Check [this test](https://github.com/yannbf/sb-utils/pull/15/changes#diff-fd786be7d3731803a0928673511495dea6464618b3ec22b2411982f36fa84bf1R85) for more info on the output.

### CLI
``` bash
npx @hipster/sb-utils analyze-component path/to/component.tsx
``` 
Analyzes a single component file or directory.

Outputs metadata including props, default values, and detected stories.

Supports optional flags for JSON output and verbosity.

### Node
```ts
import { analyzeComponent } from '@hipster/sb-utils/analyze-component';

const analysis = await analyzeComponent('src/components/Button.tsx');
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @hipster/sb-utils@0.0.8-canary.15.285ba09.0
  # or 
  yarn add @hipster/sb-utils@0.0.8-canary.15.285ba09.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
